### PR TITLE
wine-staging 1.7.49 (new formula)

### DIFF
--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -5,7 +5,7 @@
 # NOTE: wine-patched is a devel version of wine with all the wine-staging patches.
 #  Therefore, this Formula is mostly a variant of the devel-do part of wine.
 class WineStaging < Formula
-  desc "Patched wine with new, unoffical bug fixes and features."
+  desc "Unofficially patched WINE."
   homepage "https://wine-staging.com/"
   url "https://github.com/wine-compholio/wine-patched/archive/staging-1.7.49.tar.gz"
   sha256 "4c6880c0551fb5f70895f0e149fc26ae3760b0f1c0f9077c0c1e8d02436e7006"

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -165,7 +165,7 @@ class WineStaging < Formula
       EOS
     end
   end
- 
+
   test do
     system "#{bin}/wine", "cmd", "/C", "exit 0"
   end

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -163,7 +163,7 @@ class WineStaging < Formula
         For best results with X11, install the latest version of XQuartz:
           https://xquartz.macosforge.org/
       EOS
-    s
+      s
     end
   end
 

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -7,8 +7,8 @@
 class WineStaging < Formula
   desc "Patched wine with new, unoffical bug fixes and features."
   homepage "https://wine-staging.com/"
-  url "https://github.com/wine-compholio/wine-patched/archive/staging-1.7.45.tar.gz"
-  sha256 "cd2767ce64071c6662e9c421b0b772d080b88c7a4ce00c0f7db5fe70e5f3f628"
+  url "https://github.com/wine-compholio/wine-patched/archive/staging-1.7.49.tar.gz"
+  sha256 "4c6880c0551fb5f70895f0e149fc26ae3760b0f1c0f9077c0c1e8d02436e7006"
 
   # Patch to fix screen-flickering issues. Still relevant on 1.7.23.
   # https://bugs.winehq.org/show_bug.cgi?id=34166

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -7,8 +7,8 @@
 class WineStaging < Formula
   desc "Patched wine with new bug fixes and features that are not yet merged upstream."
   homepage "https://wine-staging.com/"
-  url 'https://github.com/wine-compholio/wine-patched/archive/staging-1.7.45.tar.gz'
-  sha256 'cd2767ce64071c6662e9c421b0b772d080b88c7a4ce00c0f7db5fe70e5f3f628'
+  url "https://github.com/wine-compholio/wine-patched/archive/staging-1.7.45.tar.gz"
+  sha256 "cd2767ce64071c6662e9c421b0b772d080b88c7a4ce00c0f7db5fe70e5f3f628"
 
   option "without-gecko", "Let wine download wine-gecko for iexplore emulation itself."
   option "without-mono", "Let wine download wine-mono for .NET programs itself."
@@ -35,33 +35,33 @@ class WineStaging < Formula
   # Wine will build both the Mac and the X11 driver by default, and you can switch
   # between them. But if you really want to build without X11, you can.
   depends_on :x11 => :recommended
-  depends_on 'pkg-config' => :build
-  depends_on 'freetype'
-  depends_on 'jpeg'
-  depends_on 'libgphoto2'
-  depends_on 'little-cms2'
-  depends_on 'libicns'
-  depends_on 'libtiff'
-  depends_on 'sane-backends'
-  depends_on 'libgsm' => :optional
+  depends_on "pkg-config" => :build
+  depends_on "freetype"
+  depends_on "jpeg"
+  depends_on "libgphoto2"
+  depends_on "little-cms2"
+  depends_on "libicns"
+  depends_on "libtiff"
+  depends_on "sane-backends"
+  depends_on "libgsm" => :optional
   # devel dependencies:
   depends_on "samba" => :optional
   depends_on "gnutls"
   conflicts_with "wine", :because => "wine-staging shares all filenames with wine."
 
-  resource 'gecko' do
+  resource "gecko" do
     url "https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi", :using => :nounzip
     sha256 "afa457ce8f9885225b6e549dd6f154713ce15bf063c23e38c1327d2f869e128a"
   end
 
-  resource 'mono' do
+  resource "mono" do
     url "https://downloads.sourceforge.net/wine/wine-mono-4.5.6.msi", :using => :nounzip
     sha256 "ac681f737f83742d786706529eb85f4bc8d6bdddd8dcdfa9e2e336b71973bc25"
   end
 
   fails_with :llvm do
     build 2336
-    cause 'llvm-gcc does not respect force_align_arg_pointer'
+    cause "llvm-gcc does not respect force_align_arg_pointer"
   end
 
   fails_with :clang do
@@ -79,8 +79,8 @@ class WineStaging < Formula
 
   def library_path
     paths = %W[#{HOMEBREW_PREFIX}/lib /usr/lib]
-    paths.unshift(MacOS::X11.lib) if build.with? 'x11'
-    paths.join(':')
+    paths.unshift(MacOS::X11.lib) if build.with? "x11"
+    paths.join(":")
   end
 
   def wine_wrapper; <<-EOS.undent
@@ -102,7 +102,7 @@ class WineStaging < Formula
     # 64-bit builds of mpg123 are incompatible with 32-bit builds of Wine
     args << "--without-mpg123" if Hardware.is_64_bit?
 
-    args << "--without-x" if build.without? 'x11'
+    args << "--without-x" if build.without? "x11"
 
     system "./configure", *args
 
@@ -128,16 +128,16 @@ class WineStaging < Formula
     end
 
     system "make", "install"
-    (share/'wine/gecko').install resource('gecko') if build.with? "gecko"
-    (share/'wine/mono').install resource('mono') if build.with? "mono"
+    (share/"wine/gecko").install resource("gecko") if build.with? "gecko"
+    (share/"wine/mono").install resource("mono") if build.with? "mono"
 
     # Use a wrapper script, so rename wine to wine.bin
     # and name our startup script wine
-    mv bin/'wine', bin/'wine.bin'
-    (bin/'wine').write(wine_wrapper)
+    mv bin/"wine", bin/"wine.bin"
+    (bin/"wine").write(wine_wrapper)
 
     # Don't need Gnome desktop support
-    (share/'applications').rmtree
+    (share/"applications").rmtree
   end
 
   test do
@@ -156,7 +156,7 @@ class WineStaging < Formula
         https://bugs.winehq.org/show_bug.cgi?id=31374
     EOS
 
-    if build.with? 'x11'
+    if build.with? "x11"
       s += <<-EOS.undent
 
         By default Wine uses a native Mac driver. To switch to the X11 driver, use

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -21,7 +21,7 @@ class WineStaging < Formula
   end
 
   head do
-    url "git://github.com/wine-compholio/wine-patched/wine.git"
+    url "https://github.com/wine-compholio/wine-patched/wine.git"
 
     option "with-win64", "Build with win64 emulator (won't run 32-bit binaries.)"
   end

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -29,6 +29,9 @@ class WineStaging < Formula
     MacOS.prefer_64_bit?
   end
 
+  option "without-gecko", "Let wine download wine-gecko for iexplore emulation itself."
+  option "without-mono", "Let wine download wine-mono for .NET programs itself."
+
   # Wine will build both the Mac and the X11 driver by default, and you can switch
   # between them. But if you really want to build without X11, you can.
   depends_on :x11 => :recommended
@@ -45,9 +48,6 @@ class WineStaging < Formula
   depends_on "samba" => :optional
   depends_on "gnutls"
   conflicts_with "wine", :because => "wine-staging shares all filenames with wine."
-
-  option "without-gecko", "Let wine download wine-gecko for iexplore emulation itself."
-  option "without-mono", "Let wine download wine-mono for .NET programs itself."
 
   resource "gecko" do
     url "https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi", :using => :nounzip
@@ -113,7 +113,8 @@ class WineStaging < Formula
       inreplace "dlls/winemac.drv/Makefile" do |s|
         # We need to use the real compiler, not the superenv shim, which will exec the
         # configured compiler no matter what name is used to invoke it.
-        cc, cxx = s.get_make_var("CC"), s.get_make_var("CXX")
+        cc = s.get_make_var("CC")
+        cxx = s.get_make_var("CXX")
         s.change_make_var! "CC", cc.sub(ENV.cc, "xcrun clang") if cc
         s.change_make_var! "CXX", cc.sub(ENV.cxx, "xcrun clang++") if cxx
 
@@ -163,9 +164,8 @@ class WineStaging < Formula
           https://xquartz.macosforge.org/
       EOS
     end
-    return s
   end
-  
+ 
   test do
     system "#{bin}/wine", "cmd", "/C", "exit 0"
   end

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -1,27 +1,17 @@
-require 'formula'
-
 # NOTE: When updating Wine, please check Wine-Gecko and Wine-Mono for updates
 # too:
 #  - http://wiki.winehq.org/Gecko
 #  - http://wiki.winehq.org/Mono
 # NOTE: wine-patched is a devel version of wine with all the wine-staging patches.
-#       Therefore, this Formula is mostly a variant of the devel-do part of wine.
+#  Therefore, this Formula is mostly a variant of the devel-do part of wine.
 class WineStaging < Formula
-  desc "A patched wine version containing bug fixes and features that are not yet available upstream. "
-  homepage 'https://wine-staging.com/'
+  desc "Patched wine with new bug fixes and features that are not yet merged upstream."
+  homepage "https://wine-staging.com/"
   url 'https://github.com/wine-compholio/wine-patched/archive/staging-1.7.45.tar.gz'
   sha256 'cd2767ce64071c6662e9c421b0b772d080b88c7a4ce00c0f7db5fe70e5f3f628'
-  conflicts_with "wine", :because => "wine-staging shares all filenames with wine."
 
-  resource 'gecko' do
-    url 'https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi', :using => :nounzip
-    sha256 'afa457ce8f9885225b6e549dd6f154713ce15bf063c23e38c1327d2f869e128a'
-  end
-
-  resource 'mono' do
-    url 'https://downloads.sourceforge.net/wine/wine-mono-4.5.6.msi', :using => :nounzip
-    sha256 'ac681f737f83742d786706529eb85f4bc8d6bdddd8dcdfa9e2e336b71973bc25'
-  end
+  option "without-gecko", "Let wine download wine-gecko for iexplore emulation itself."
+  option "without-mono", "Let wine download wine-mono for .NET programs itself."
 
   # Patch to fix screen-flickering issues. Still relevant on 1.7.23.
   # https://bugs.winehq.org/show_bug.cgi?id=34166
@@ -32,8 +22,8 @@ class WineStaging < Formula
 
   head do
     url "git://github.com/wine-compholio/wine-patched/wine.git"
-    option "with-win64",
-           "Build with win64 emulator (won't run 32-bit binaries.)"
+
+    option "with-win64", "Build with win64 emulator (won't run 32-bit binaries.)"
   end
 
   # note that all wine dependencies should declare a --universal option in their formula,
@@ -57,6 +47,7 @@ class WineStaging < Formula
   # devel dependencies:
   depends_on "samba" => :optional
   depends_on "gnutls"
+  conflicts_with "wine", :because => "wine-staging shares all filenames with wine."
 
   resource 'gecko' do
     url "https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi", :using => :nounzip
@@ -136,9 +127,9 @@ class WineStaging < Formula
       end
     end
 
-    system "make install"
-    (share/'wine/gecko').install resource('gecko')
-    (share/'wine/mono').install resource('mono')
+    system "make", "install"
+    (share/'wine/gecko').install resource('gecko') if build.with? "gecko"
+    (share/'wine/mono').install resource('mono') if build.with? "mono"
 
     # Use a wrapper script, so rename wine to wine.bin
     # and name our startup script wine

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -1,0 +1,177 @@
+require 'formula'
+
+# NOTE: When updating Wine, please check Wine-Gecko and Wine-Mono for updates
+# too:
+#  - http://wiki.winehq.org/Gecko
+#  - http://wiki.winehq.org/Mono
+# NOTE: wine-patched is a devel version of wine with all the wine-staging patches.
+#       Therefore, this Formula is mostly a variant of the devel-do part of wine.
+class WineStaging < Formula
+  desc "A patched wine version containing bug fixes and features that are not yet available upstream. "
+  homepage 'https://wine-staging.com/'
+  url 'https://github.com/wine-compholio/wine-patched/archive/staging-1.7.45.tar.gz'
+  sha256 'cd2767ce64071c6662e9c421b0b772d080b88c7a4ce00c0f7db5fe70e5f3f628'
+  conflicts_with "wine", :because => "wine-staging shares all filenames with wine."
+
+  resource 'gecko' do
+    url 'https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi', :using => :nounzip
+    sha256 'afa457ce8f9885225b6e549dd6f154713ce15bf063c23e38c1327d2f869e128a'
+  end
+
+  resource 'mono' do
+    url 'https://downloads.sourceforge.net/wine/wine-mono-4.5.6.msi', :using => :nounzip
+    sha256 'ac681f737f83742d786706529eb85f4bc8d6bdddd8dcdfa9e2e336b71973bc25'
+  end
+
+  # Patch to fix screen-flickering issues. Still relevant on 1.7.23.
+  # https://bugs.winehq.org/show_bug.cgi?id=34166
+  patch do
+    url "https://bugs.winehq.org/attachment.cgi?id=47639"
+    sha256 "3054467e0b1ef9efce3e1b24497bd26e00c4727e8bd7b1e990d1352bb1819de0"
+  end
+
+  head do
+    url "git://github.com/wine-compholio/wine-patched/wine.git"
+    option "with-win64",
+           "Build with win64 emulator (won't run 32-bit binaries.)"
+  end
+
+  # note that all wine dependencies should declare a --universal option in their formula,
+  # otherwise homebrew will not notice that they are not built universal
+  def require_universal_deps?
+    MacOS.prefer_64_bit?
+  end
+
+  # Wine will build both the Mac and the X11 driver by default, and you can switch
+  # between them. But if you really want to build without X11, you can.
+  depends_on :x11 => :recommended
+  depends_on 'pkg-config' => :build
+  depends_on 'freetype'
+  depends_on 'jpeg'
+  depends_on 'libgphoto2'
+  depends_on 'little-cms2'
+  depends_on 'libicns'
+  depends_on 'libtiff'
+  depends_on 'sane-backends'
+  depends_on 'libgsm' => :optional
+  # devel dependencies:
+  depends_on "samba" => :optional
+  depends_on "gnutls"
+
+  resource 'gecko' do
+    url "https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi", :using => :nounzip
+    sha256 "afa457ce8f9885225b6e549dd6f154713ce15bf063c23e38c1327d2f869e128a"
+  end
+
+  resource 'mono' do
+    url "https://downloads.sourceforge.net/wine/wine-mono-4.5.6.msi", :using => :nounzip
+    sha256 "ac681f737f83742d786706529eb85f4bc8d6bdddd8dcdfa9e2e336b71973bc25"
+  end
+
+  fails_with :llvm do
+    build 2336
+    cause 'llvm-gcc does not respect force_align_arg_pointer'
+  end
+
+  fails_with :clang do
+    build 425
+    cause "Clang prior to Xcode 5 miscompiles some parts of wine"
+  end
+
+  # These libraries are not specified as dependencies, or not built as 32-bit:
+  # configure: libv4l, gstreamer-0.10, libcapi20, libgsm
+
+  # Wine loads many libraries lazily using dlopen calls, so it needs these paths
+  # to be searched by dyld.
+  # Including /usr/lib because wine, as of 1.3.15, tries to dlopen
+  # libncurses.5.4.dylib, and fails to find it without the fallback path.
+
+  def library_path
+    paths = %W[#{HOMEBREW_PREFIX}/lib /usr/lib]
+    paths.unshift(MacOS::X11.lib) if build.with? 'x11'
+    paths.join(':')
+  end
+
+  def wine_wrapper; <<-EOS.undent
+    #!/bin/sh
+    DYLD_FALLBACK_LIBRARY_PATH="#{library_path}" "#{bin}/wine.bin" "$@"
+    EOS
+  end
+
+  def install
+    ENV.m32 # Build 32-bit; Wine doesn't support 64-bit host builds on OS X.
+
+    # Help configure find libxml2 in an XCode only (no CLT) installation.
+    ENV.libxml2
+
+    args = ["--prefix=#{prefix}"]
+    args << "--disable-win16" if MacOS.version <= :leopard
+    args << "--enable-win64" if build.with? "win64"
+
+    # 64-bit builds of mpg123 are incompatible with 32-bit builds of Wine
+    args << "--without-mpg123" if Hardware.is_64_bit?
+
+    args << "--without-x" if build.without? 'x11'
+
+    system "./configure", *args
+
+    # The Mac driver uses blocks and must be compiled with an Apple compiler
+    # even if the rest of Wine is built with A GNU compiler.
+    unless ENV.compiler == :clang || ENV.compiler == :llvm || ENV.compiler == :gcc
+      system "make", "dlls/winemac.drv/Makefile"
+      inreplace "dlls/winemac.drv/Makefile" do |s|
+        # We need to use the real compiler, not the superenv shim, which will exec the
+        # configured compiler no matter what name is used to invoke it.
+        cc, cxx = s.get_make_var("CC"), s.get_make_var("CXX")
+        s.change_make_var! "CC", cc.sub(ENV.cc, "xcrun clang") if cc
+        s.change_make_var! "CXX", cc.sub(ENV.cxx, "xcrun clang++") if cxx
+
+        # Emulate some things that superenv would normally handle for us
+        # We're configured to use GNU GCC, so remote an unsupported flag
+        s.gsub! "-gstabs+", ""
+        # Pass the sysroot to support Xcode-only systems
+        cflags  = s.get_make_var("CFLAGS")
+        cflags += " --sysroot=#{MacOS.sdk_path}"
+        s.change_make_var! "CFLAGS", cflags
+      end
+    end
+
+    system "make install"
+    (share/'wine/gecko').install resource('gecko')
+    (share/'wine/mono').install resource('mono')
+
+    # Use a wrapper script, so rename wine to wine.bin
+    # and name our startup script wine
+    mv bin/'wine', bin/'wine.bin'
+    (bin/'wine').write(wine_wrapper)
+
+    # Don't need Gnome desktop support
+    (share/'applications').rmtree
+  end
+
+  def caveats
+    s = <<-EOS.undent
+      You may want to get winetricks:
+        brew install winetricks
+
+      The current version of Wine contains a partial implementation of dwrite.dll
+      which may cause text rendering issues in applications such as Steam.
+      We recommend that you run winecfg, add an override for dwrite in the
+      Libraries tab, and edit the override mode to "disable". See:
+        https://bugs.winehq.org/show_bug.cgi?id=31374
+    EOS
+
+    if build.with? 'x11'
+      s += <<-EOS.undent
+
+        By default Wine uses a native Mac driver. To switch to the X11 driver, use
+        regedit to set the "graphics" key under "HKCU\Software\Wine\Drivers" to
+        "x11" (or use winetricks).
+
+        For best results with X11, install the latest version of XQuartz:
+          https://xquartz.macosforge.org/
+      EOS
+    end
+    return s
+  end
+end

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -140,6 +140,10 @@ class WineStaging < Formula
     (share/'applications').rmtree
   end
 
+  test do
+    system "#{bin}/wine", "cmd", "/C", "exit 0"
+  end
+
   def caveats
     s = <<-EOS.undent
       You may want to get winetricks:

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -120,7 +120,7 @@ class WineStaging < Formula
 
         # Emulate some things that superenv would normally handle for us
         # We're configured to use GNU GCC, so remote an unsupported flag
-        s.gsub! "-gstabs+", ""
+        s.gsub! "-gstabs+", "" if build.stable?
         # Pass the sysroot to support Xcode-only systems
         cflags  = s.get_make_var("CFLAGS")
         cflags += " --sysroot=#{MacOS.sdk_path}"
@@ -163,6 +163,7 @@ class WineStaging < Formula
         For best results with X11, install the latest version of XQuartz:
           https://xquartz.macosforge.org/
       EOS
+    s
     end
   end
 

--- a/Formula/wine-staging.rb
+++ b/Formula/wine-staging.rb
@@ -5,13 +5,10 @@
 # NOTE: wine-patched is a devel version of wine with all the wine-staging patches.
 #  Therefore, this Formula is mostly a variant of the devel-do part of wine.
 class WineStaging < Formula
-  desc "Patched wine with new bug fixes and features that are not yet merged upstream."
+  desc "Patched wine with new, unoffical bug fixes and features."
   homepage "https://wine-staging.com/"
   url "https://github.com/wine-compholio/wine-patched/archive/staging-1.7.45.tar.gz"
   sha256 "cd2767ce64071c6662e9c421b0b772d080b88c7a4ce00c0f7db5fe70e5f3f628"
-
-  option "without-gecko", "Let wine download wine-gecko for iexplore emulation itself."
-  option "without-mono", "Let wine download wine-mono for .NET programs itself."
 
   # Patch to fix screen-flickering issues. Still relevant on 1.7.23.
   # https://bugs.winehq.org/show_bug.cgi?id=34166
@@ -48,6 +45,9 @@ class WineStaging < Formula
   depends_on "samba" => :optional
   depends_on "gnutls"
   conflicts_with "wine", :because => "wine-staging shares all filenames with wine."
+
+  option "without-gecko", "Let wine download wine-gecko for iexplore emulation itself."
+  option "without-mono", "Let wine download wine-mono for .NET programs itself."
 
   resource "gecko" do
     url "https://downloads.sourceforge.net/wine/wine_gecko-2.36-x86.msi", :using => :nounzip
@@ -140,10 +140,6 @@ class WineStaging < Formula
     (share/"applications").rmtree
   end
 
-  test do
-    system "#{bin}/wine", "cmd", "/C", "exit 0"
-  end
-
   def caveats
     s = <<-EOS.undent
       You may want to get winetricks:
@@ -168,5 +164,9 @@ class WineStaging < Formula
       EOS
     end
     return s
+  end
+  
+  test do
+    system "#{bin}/wine", "cmd", "/C", "exit 0"
   end
 end


### PR DESCRIPTION
[wine-staging](wine-staging.com), an unofficial place to collect wine patches and prepare them for sending to upstream, is popular among Linux users, since the wine upstream is often considered as being slow and strict to accept new patches.

This PR introduces an pre-patched git tag version to the Homebrew repository. Since it's based on the current devel version of wine, I have to put it here in homebrew-devel-only.