### PR TITLE
juju2 2.0-beta13 (devel)

### DIFF
--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -1,0 +1,25 @@
+class Juju2 < Formula
+  desc "DevOps management tool"
+  homepage "https://jujucharms.com/"
+
+  devel do
+    url "https://launchpad.net/juju-core/trunk/2.0-beta10/+download/juju-core_2.0-beta10.tar.gz"
+    sha256 "ca1ed827c27b345884aff7e316d54b4929a7e38d6442ffd72d05dd797e8870c8"
+    version "2.0-beta10"
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    system "go", "build", "github.com/juju/juju/cmd/juju"
+    system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
+    bin.install "juju", "juju-metadata"
+    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju2"
+    end
+  end
+
+  test do
+    system "#{bin}/juju", "version"
+  end
+end

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -20,6 +20,6 @@ class Juju2 < Formula
   end
 
   test do
-    system "#{bin}/juju2", "version"
+    system "#{bin}/juju", "version"
   end
 end

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -3,7 +3,7 @@ class Juju2 < Formula
   homepage "https://jujucharms.com/"
 
   devel do
-    url "https://launchpad.net/juju-core/trunk/2.0-beta10/+download/juju-core_2.0-beta11.tar.gz"
+    url "https://launchpad.net/juju-core/trunk/2.0-beta11/+download/juju-core_2.0-beta11.tar.gz"
     sha256 "4aaaad717106d7b802a9d06ced1723d5a9a2837c831eb75deaec2bd574693ff9"
     version "2.0-beta11"
   end

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -3,9 +3,9 @@ class Juju2 < Formula
   homepage "https://jujucharms.com/"
 
   devel do
-    url "https://launchpad.net/juju-core/trunk/2.0-beta11/+download/juju-core_2.0-beta11.tar.gz"
-    sha256 "4aaaad717106d7b802a9d06ced1723d5a9a2837c831eb75deaec2bd574693ff9"
-    version "2.0-beta11"
+    url "https://launchpad.net/juju-core/trunk/2.0-beta12/+download/juju-core_2.0-beta12.tar.gz"
+    sha256 "1d65b020ce9c79b281ca3e17eadfb3451912052114db3c59040b151ed8464e78"
+    version "2.0-beta12"
   end
 
   depends_on "go" => :build
@@ -14,7 +14,7 @@ class Juju2 < Formula
     ENV["GOPATH"] = buildpath
     system "go", "build", "github.com/juju/juju/cmd/juju"
     system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
-    bin.install "juju", "juju-metadata"
+    bin.install "juju" => "juju2", "juju-metadata" => "juju-metadata2"
     bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
   end
 

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -16,7 +16,6 @@ class Juju2 < Formula
     system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
     bin.install "juju", "juju-metadata"
     bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju2"
-    end
   end
 
   test do

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -9,12 +9,13 @@ class Juju2 < Formula
   end
 
   depends_on "go" => :build
+  conflicts_with "juju", :because => "juju and juju2 cannot be installed simultaneously, and juju environments aren't compatible with juju2"
 
   def install
     ENV["GOPATH"] = buildpath
     system "go", "build", "github.com/juju/juju/cmd/juju"
     system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
-    bin.install "juju" => "juju2", "juju-metadata" => "juju-metadata2"
+    bin.install "juju", "juju-metadata"
     bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
   end
 

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -3,9 +3,9 @@ class Juju2 < Formula
   homepage "https://jujucharms.com/"
 
   devel do
-    url "https://launchpad.net/juju-core/trunk/2.0-beta12/+download/juju-core_2.0-beta12.tar.gz"
-    sha256 "1d65b020ce9c79b281ca3e17eadfb3451912052114db3c59040b151ed8464e78"
-    version "2.0-beta12"
+    url "https://launchpad.net/juju-core/trunk/2.0-beta13/+download/juju-core_2.0-beta13.tar.gz"
+    sha256 "36be9ff1266b430b43749cc5eeed14d6fa9ece306ed135aca72e82daab7554fc"
+    version "2.0-beta13"
   end
 
   depends_on "go" => :build

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -15,7 +15,7 @@ class Juju2 < Formula
     system "go", "build", "github.com/juju/juju/cmd/juju"
     system "go", "build", "github.com/juju/juju/cmd/plugins/juju-metadata"
     bin.install "juju", "juju-metadata"
-    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju2"
+    bash_completion.install "src/github.com/juju/juju/etc/bash_completion.d/juju-2.0"
   end
 
   test do

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -3,9 +3,9 @@ class Juju2 < Formula
   homepage "https://jujucharms.com/"
 
   devel do
-    url "https://launchpad.net/juju-core/trunk/2.0-beta10/+download/juju-core_2.0-beta10.tar.gz"
-    sha256 "ca1ed827c27b345884aff7e316d54b4929a7e38d6442ffd72d05dd797e8870c8"
-    version "2.0-beta10"
+    url "https://launchpad.net/juju-core/trunk/2.0-beta10/+download/juju-core_2.0-beta11.tar.gz"
+    sha256 "4aaaad717106d7b802a9d06ced1723d5a9a2837c831eb75deaec2bd574693ff9"
+    version "2.0-beta11"
   end
 
   depends_on "go" => :build

--- a/Formula/juju2.rb
+++ b/Formula/juju2.rb
@@ -19,6 +19,6 @@ class Juju2 < Formula
   end
 
   test do
-    system "#{bin}/juju", "version"
+    system "#{bin}/juju2", "version"
   end
 end


### PR DESCRIPTION
Per discussion in homebrew/homebrew-core#2369, creating separate juju2 formula in --devel only mode. No --head option due to a mismatch of directory structure between github and launchpad.