### PR TITLE
Support the develop branch of libtomcrypt

### DIFF
--- a/Formula/libtomcrypt.rb
+++ b/Formula/libtomcrypt.rb
@@ -1,0 +1,28 @@
+class Libtomcrypt < Formula
+  desc "Modular and portable cryptographic toolkit"
+  homepage "http://www.libtom.net/LibTomCrypt/"
+  url "https://github.com/libtom/libtomcrypt/releases/download/1.17/crypt-1.17.tar.bz2"
+  mirror "https://distfiles.macports.org/libtomcrypt/crypt-1.17.tar.bz2"
+  sha256 "e33b47d77a495091c8703175a25c8228aff043140b2554c08a3c3cd71f79d116"
+  head "https://github.com/libtom/libtomcrypt.git"
+
+  depends_on "libtommath"
+
+  devel do
+    version "develop-head"
+    url "https://github.com/libtom/libtomcrypt.git",
+        :branch => "develop"
+
+    system "make", "library"
+  end
+
+  def install
+    ENV["DESTDIR"] = prefix
+    ENV["EXTRALIBS"] = "-ltommath"
+    ENV.append "CFLAGS", "-DLTM_DESC -DUSE_LTM"
+
+    system "make", "library"
+    include.install Dir["src/headers/*"]
+    lib.install "libtomcrypt.a"
+  end
+end


### PR DESCRIPTION
At this writing, the released tomcrypt code (1.17) will not build with the current XCode toolchain from Apple because of a problem with the inline asm macros in src/headers/tomcrypt_macros.h

The tomcrypt release is 4 years old.  The `develop` branch on github appears to be more active _and_ has a fix for the above issue.

My PR seeks to provide brew access to this `develop` branch.