### PR TITLE
unsign HEAD-only (new formula)

### DIFF
--- a/Formula/unsign.rb
+++ b/Formula/unsign.rb
@@ -1,0 +1,14 @@
+class Unsign < Formula
+  desc "Remove code signatures from OSX Mach-O binaries"
+  homepage "http://www.woodmann.com/collaborative/tools/index.php/Unsign"
+  head "https://github.com/steakknife/unsign.git"
+  
+  def install
+    system "make"
+    bin.install "unsign"
+  end
+
+  test do
+    system "[[ $(unsign) == \"usage: unsign file [outfile]\" ]]"
+  end
+end


### PR DESCRIPTION
This little tool will become very popular soon, as using it is the only currently known way of enabling 3rd party plugins in Xcode 8 (which is about to ship to a bazillion iPhone developers).

See https://github.com/alcatraz/Alcatraz/issues/475#issuecomment-225868817 for further discussion.
